### PR TITLE
More elaborate dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
       schedule:
           interval: 'weekly'
           day: 'wednesday'
+      reviewers:
+          - 'lionralfs'
+      allow:
+          - dependency-type: 'all'


### PR DESCRIPTION
- Automatically sets reviewer to @lionralfs 
- Allow dependabot updates for all dependency types