### PR TITLE
fix(commonjs): fix broken commonjs import

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,3 +31,4 @@ jobs:
     - run: npm run lint
     - run: npm test
     - run: npm run build
+    - run: cd test/commonjs && node index.js

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Here are some basic usage examples that connect with the public API. Error handl
 import { DiscogsClient } from '@lionralfs/discogs-client';
 
 // in commonjs environments
-const DiscogsClient = require('@lionralfs/discogs-client/commonjs');
+const { DiscogsClient } = require('@lionralfs/discogs-client/commonjs');
 
 // in browser environments
 import { DiscogsClient } from '@lionralfs/discogs-client/browser';

--- a/build.js
+++ b/build.js
@@ -46,5 +46,4 @@ build({
     platform: 'node',
     minify: false,
     define: { 'process.env.VERSION_NUMBER': `'${PACKAGE.version}'` },
-    external: ['node-fetch'],
 }).catch(err => console.error(err) || process.exit(1));

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
     },
     "files": [
         "browser/index.js",
+        "browser/package.json",
         "commonjs/index.js",
+        "commonjs/package.json",
         "types",
         "node-esm/index.js",
         "lib/*",

--- a/test/commonjs/index.js
+++ b/test/commonjs/index.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+const { DiscogsClient } = require('../../commonjs');
+
+let client = new DiscogsClient();
+if (!(client instanceof DiscogsClient)) {
+    process.exit(1);
+}

--- a/test/commonjs/package.json
+++ b/test/commonjs/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "commonjs"
+}


### PR DESCRIPTION
* Add integration test to ensure that the client can be instantiated in a commonjs environment
* Fix Readme on how to import the client in commonjs
* Publish nested package.json's for the browser and commonjs packages
* Inline node-fetch for the commonjs bundle (node-fetch@3 is ESM only)