### PR TITLE
feat(types): make discogs types available to library clients

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -9,7 +9,7 @@ import {
 } from './types.js';
 import { type DiscogsClient } from './client.js';
 
-type BasicReleaseInfo = {
+export type BasicReleaseInfo = {
     id: number;
     title: string;
     year: number;
@@ -30,9 +30,9 @@ type BasicReleaseInfo = {
     genres: Array<string>;
     styles: Array<string>;
 };
-type GetFoldersResponse = { folders: Array<GetFolderResponse> };
-type GetFolderResponse = { id: number; count: number; name: string; resource_url: string };
-type GetReleasesResponse = {
+export type GetFoldersResponse = { folders: Array<GetFolderResponse> };
+export type GetFolderResponse = { id: number; count: number; name: string; resource_url: string };
+export type GetReleasesResponse = {
     releases: Array<{
         id: number;
         instance_id: number;
@@ -42,7 +42,7 @@ type GetReleasesResponse = {
         notes: Array<{ field_id: number; value: string }>;
     }>;
 };
-type GetReleaseInstancesResponse = {
+export type GetReleaseInstancesResponse = {
     releases: Array<{
         id: number;
         instance_id: number;
@@ -52,8 +52,8 @@ type GetReleaseInstancesResponse = {
         date_added: string;
     }>;
 };
-type AddReleaseResponse = { instance_id: number; resource_url: string };
-type GetFieldsResponse = {
+export type AddReleaseResponse = { instance_id: number; resource_url: string };
+export type GetFieldsResponse = {
     fields: Array<{
         name: string;
         type: string;
@@ -64,7 +64,7 @@ type GetFieldsResponse = {
         lines?: number;
     }>;
 };
-type CollectionValueResponse = { maximum: string; median: string; minimum: string };
+export type CollectionValueResponse = { maximum: string; median: string; minimum: string };
 
 /**
  * @param {DiscogsClient} client

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -12,7 +12,7 @@ import {
     type Status,
 } from './types.js';
 import { toQueryString, escape } from './util.js';
-type GetArtistResponse = {
+export type GetArtistResponse = {
     name: string;
     namevariations: Array<string>;
     profile: string;
@@ -25,7 +25,7 @@ type GetArtistResponse = {
     images: Array<Image>;
     members: Array<{ active: boolean; id: number; name: string; resource_url: string }>;
 };
-type GetArtistReleasesResponses = {
+export type GetArtistReleasesResponses = {
     releases: Array<{
         artist: string;
         id: number;
@@ -38,10 +38,10 @@ type GetArtistReleasesResponses = {
         year: number;
     }>;
 };
-type GetReleaseRatingResponse = { username: string; release_id: number; rating: number };
-type GetReleaseCommunityRatingResponse = { rating: { count: number; average: number }; release_id: number };
-type GetReleaseStatsResponse = { num_have: number; num_want: number };
-type GetMasterResponse = {
+export type GetReleaseRatingResponse = { username: string; release_id: number; rating: number };
+export type GetReleaseCommunityRatingResponse = { rating: { count: number; average: number }; release_id: number };
+export type GetReleaseStatsResponse = { num_have: number; num_want: number };
+export type GetMasterResponse = {
     styles: Array<string>;
     genres: Array<string>;
     videos: Array<{ duration: number; description: string; embed: boolean; uri: string; title: string }>;
@@ -60,7 +60,7 @@ type GetMasterResponse = {
     lowest_price: number;
     data_quality: string;
 };
-type GetMasterVersionsResponse = {
+export type GetMasterVersionsResponse = {
     versions: Array<{
         status: Status;
         stats: {
@@ -79,7 +79,7 @@ type GetMasterVersionsResponse = {
         id: number;
     }>;
 };
-type GetLabelResponse = {
+export type GetLabelResponse = {
     profile: string;
     releases_url: string;
     name: string;
@@ -92,7 +92,7 @@ type GetLabelResponse = {
     id: number;
     data_quality: string;
 };
-type GetLabelReleasesResponse = {
+export type GetLabelReleasesResponse = {
     releases: Array<{
         artist: string;
         catno: string;
@@ -105,7 +105,7 @@ type GetLabelReleasesResponse = {
         year: number;
     }>;
 };
-interface SearchResult {
+export interface SearchResult {
     id: number;
     type: string;
     user_data: UserData;
@@ -129,26 +129,26 @@ interface SearchResult {
     formats?: Format[];
 }
 
-interface UserData {
+export interface UserData {
     in_wantlist: boolean;
     in_collection: boolean;
 }
 
-interface Community {
+export interface Community {
     want: number;
     have: number;
 }
 
-interface Format {
+export interface Format {
     name: string;
     qty: string;
     descriptions?: string[];
 }
 
-type SearchResponse = {
+export type SearchResponse = {
     results: Array<SearchResult>;
 };
-type SearchParameters = {
+export type SearchParameters = {
     query: string;
     type: 'release' | 'master' | 'artist' | 'label';
     title: string;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,3 +12,15 @@ export { DiscogsClient } from './client.js';
  * Expose Discogs OAuth class
  */
 export { DiscogsOAuth } from './oauth.js';
+
+/**
+ * Expose all types from the "submodules"
+ */
+export type * from './collection.js';
+export type * from './database.js';
+export type * from './inventory.js';
+export type * from './list.js';
+export type * from './marketplace.js';
+export type * from './types.js';
+export type * from './user.js';
+export type * from './wantlist.js';

--- a/lib/inventory.ts
+++ b/lib/inventory.ts
@@ -2,10 +2,10 @@ import { type DiscogsClient } from './client.js';
 import { type PaginationParameters, type PaginationResponse, type RateLimitedResponse } from './types.js';
 import { toQueryString } from './util.js';
 
-type GetInventoryExportsResponse = {
+export type GetInventoryExportsResponse = {
     items: Array<GetInventoryExportResponse>;
 };
-type GetInventoryExportResponse = {
+export type GetInventoryExportResponse = {
     status: string;
     created_ts: string;
     url: string;

--- a/lib/list.ts
+++ b/lib/list.ts
@@ -2,7 +2,7 @@ import { type DiscogsClient } from './client.js';
 import type { RateLimitedResponse } from './types.js';
 import { escape } from './util.js';
 
-type GetListItemsResponse = {
+export type GetListItemsResponse = {
     created_ts: string;
     modified_ts: string;
     name: string;

--- a/lib/marketplace.ts
+++ b/lib/marketplace.ts
@@ -12,7 +12,7 @@ import {
 import user from './user.js';
 import { toQueryString } from './util.js';
 
-type Condition =
+export type Condition =
     | 'Mint (M)'
     | 'Near Mint (NM or M-)'
     | 'Very Good Plus (VG+)'
@@ -21,8 +21,8 @@ type Condition =
     | 'Good (G)'
     | 'Fair (F)'
     | 'Poor (P)';
-type SleeveCondition = Condition | 'Generic' | 'Not Graded' | 'No Cover';
-type OrderStatus =
+export type SleeveCondition = Condition | 'Generic' | 'Not Graded' | 'No Cover';
+export type OrderStatus =
     | 'New Order'
     | 'Buyer Contacted'
     | 'Invoice Sent'
@@ -33,8 +33,8 @@ type OrderStatus =
     | 'Cancelled (Non-Paying Buyer)'
     | 'Cancelled (Item Unavailable)'
     | "Cancelled (Per Buyer's Request)";
-type Order = { resource_url: string; id: number };
-type OrderMessage = {
+export type Order = { resource_url: string; id: number };
+export type OrderMessage = {
     timestamp: string;
     message: string;
     type: string;
@@ -47,8 +47,8 @@ type OrderMessage = {
     original?: number;
     new?: number;
 };
-type AddListingResponse = { listing_id: number; resource_url: string };
-type GetOrderResponse = {
+export type AddListingResponse = { listing_id: number; resource_url: string };
+export type GetOrderResponse = {
     id: number;
     resource_url: string;
     messages_url: string;
@@ -73,7 +73,7 @@ type GetOrderResponse = {
     buyer: { resource_url: string; username: string; id: number };
     total: Price;
 };
-type GetReleaseStatsResponse = { lowest_price?: Price; num_for_sale?: number; blocked_from_sale: boolean };
+export type GetReleaseStatsResponseMarketplace = { lowest_price?: Price; num_for_sale?: number; blocked_from_sale: boolean };
 
 /**
  * @param {DiscogsClient} client
@@ -357,7 +357,7 @@ export default function (client: DiscogsClient) {
          * and whether the item is blocked for sale in the marketplace.
          * @param {number} release
          * @param {Currency} [currency]
-         * @returns {Promise<RateLimitedResponse<GetReleaseStatsResponse>>}
+         * @returns {Promise<RateLimitedResponse<GetReleaseStatsResponseMarketplace>>}
          *
          * @see https://www.discogs.com/developers/#page:marketplace,header:marketplace-release-statistics-get
          *
@@ -367,12 +367,12 @@ export default function (client: DiscogsClient) {
         getReleaseStats: function (
             release: number,
             currency?: Currency
-        ): Promise<RateLimitedResponse<GetReleaseStatsResponse>> {
+        ): Promise<RateLimitedResponse<GetReleaseStatsResponseMarketplace>> {
             let path = `/marketplace/stats/${release}`;
             if (currency) {
                 path += `${toQueryString({ curr_abbr: currency })}`;
             }
-            return client.get(path) as Promise<RateLimitedResponse<GetReleaseStatsResponse>>;
+            return client.get(path) as Promise<RateLimitedResponse<GetReleaseStatsResponseMarketplace>>;
         },
     };
 }

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -14,7 +14,7 @@ import list from './list.js';
 import { escape, toQueryString } from './util.js';
 import wantlist from './wantlist.js';
 
-type GetProfileResponse = {
+export type GetProfileResponse = {
     email?: string;
     num_unread?: number;
     activated: boolean;
@@ -52,9 +52,9 @@ type GetProfileResponse = {
     seller_num_ratings: number;
     curr_abbr: Currency;
 };
-type GetInventoryResponse = { listings: Array<Listing> };
-type GetContributionsResponse = { contributions: Array<GetReleaseResponse> };
-type GetSubmissionsResponse = {
+export type GetInventoryResponse = { listings: Array<Listing> };
+export type GetContributionsResponse = { contributions: Array<GetReleaseResponse> };
+export type GetSubmissionsResponse = {
     submissions: {
         artists: Array<{
             data_quality: string;
@@ -69,7 +69,7 @@ type GetSubmissionsResponse = {
         releases: Array<GetReleaseResponse>;
     };
 };
-type GetListsResponse = {
+export type GetListsResponse = {
     lists: Array<{
         date_added: string;
         date_changed: string;

--- a/lib/wantlist.ts
+++ b/lib/wantlist.ts
@@ -8,8 +8,8 @@ import {
 } from './types.js';
 import { escape, toQueryString } from './util.js';
 
-type Format = { text: string; qty: number; descriptions: Array<string>; name: string };
-type WantlistEntryResponse = {
+export type WantlistFormat = { text: string; qty: number; descriptions: Array<string>; name: string };
+export type WantlistEntryResponse = {
     resource_url: string;
     id: number;
     notes?: string;
@@ -17,7 +17,7 @@ type WantlistEntryResponse = {
     basic_information: {
         resource_url: string;
         id: number;
-        formats: Array<Format>;
+        formats: Array<WantlistFormat>;
         thumb: string;
         cover_image: string;
         title: string;


### PR DESCRIPTION
Fixes #295 through a re-export in the index.ts which allows importing types like this:

```ts
import {
  DiscogsClient,
  type GetProfileResponse,
  type RateLimitedResponse,
  type WantlistEntryResponse,
} from '@lionralfs/discogs-client';
```