### PR TITLE
Fix docstring in `collection().addRelease()` method and add styles and genres to `WantListEntryReponse` type

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -220,7 +220,7 @@ export default function (client: DiscogsClient) {
          * @see https://www.discogs.com/developers/#page:user-collection,header:user-collection-add-to-collection-folder-post
          *
          * @example
-         * await client.user().collection().addRelease('rodneyfool', 3, 130076);
+         * await client.user().collection().addRelease('rodneyfool', 130076, 3);
          */
         addRelease: function (
             user: string,

--- a/lib/wantlist.ts
+++ b/lib/wantlist.ts
@@ -24,6 +24,8 @@ export type WantlistEntryResponse = {
         labels: Array<LabelShort>;
         year: number;
         artists: Array<Artist>;
+        genres: Array<string>;
+        styles: Array<string>;
     };
 };
 


### PR DESCRIPTION
I found two tiny things that can be improved while working with the library

1. The order of arguments folder and releaseId is swapped in the Documentation bit of the addRelease method
2. The Discogs Api returns styles and genres for want list releases as well. Even though it's not part of their API docs it might be worth adding as it helps working with it in typescrip