### PR TITLE
Edit instance note fix, value needs to be in body, not query. Discogs documentation is not correct.

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -332,8 +332,8 @@ export default function (client: DiscogsClient) {
         ): Promise<RateLimitedResponse<void>> {
             const path = `/users/${escape(
                 user
-            )}/collection/folders/${folder}/releases/${release}/instances/${instance}/fields/${field}?value=${value}`;
-            return client.post(path, undefined) as Promise<RateLimitedResponse<void>>;
+            )}/collection/folders/${folder}/releases/${release}/instances/${instance}/fields/${field}`;
+            return client.post(path, { value }) as Promise<RateLimitedResponse<void>>;
         },
 
         /**

--- a/test/integration/collection.test.ts
+++ b/test/integration/collection.test.ts
@@ -177,11 +177,11 @@ describe('Collection', () => {
             http.post(
                 'https://api.discogs.com/users/rodneyfool/collection/folders/3/releases/130076/instances/1/fields/8',
                 async ({ request }) => {
-                    const body = await request.text();
+                    const body = await request.json();
                     const url = new URL(request.url);
 
-                    expect(url.searchParams.get('value')).toBe('foo');
-                    expect(body).toBe('');
+                    expect(url.searchParams.get('value')).toBeNull();
+                    expect(body).toStrictEqual({ value: 'foo' });
                     return new Response(null, { status: 204 });
                 }
             )


### PR DESCRIPTION
Hi,
I've been making app for my collection. I feel that discogs app doesn't have nice UI.
And I'm using your library, thank you for that!

Also I got many custom fields, and I wanted to edit them, but it turned out, that discogs documentation is not correct in this case.
https://www.discogs.com/developers/#page:user-collection,header:user-collection-edit-fields-instance-post

According to the docs, we should send value in URL parameters. But in reality, if you do that, you'll get following error from the API.
```json
{
    "detail": [
        {
            "type": "missing",
            "loc": [
                "body"
            ],
            "msg": "Field required",
            "input": null
        }
    ],
    "message": "See \"detail\" for validation errors."
}
```

Instead you need to send value of the field in request body. 